### PR TITLE
[Feat] 약 이름 검색, 약 상세 정보 API 구현

### DIFF
--- a/src/main/java/com/allergenie/server/controller/MedicineController.java
+++ b/src/main/java/com/allergenie/server/controller/MedicineController.java
@@ -1,0 +1,24 @@
+package com.allergenie.server.controller;
+
+import com.allergenie.server.dto.response.MedicineInfoDto;
+import com.allergenie.server.dto.response.MedicineListDto;
+import com.allergenie.server.service.MedicineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/home")
+public class MedicineController {
+    private final MedicineService medicineService;
+
+    @GetMapping
+    public MedicineListDto getMedicineListBySearch(@RequestParam("search") String search) {
+        return medicineService.getMedicineListBySearch(search);
+    }
+
+    @GetMapping("/{medicineId}")
+    public MedicineInfoDto getMedecineInfo(@PathVariable Long medicineId) {
+        return medicineService.getMedicineInfo(medicineId);
+    }
+}

--- a/src/main/java/com/allergenie/server/controller/MedicineController.java
+++ b/src/main/java/com/allergenie/server/controller/MedicineController.java
@@ -4,6 +4,8 @@ import com.allergenie.server.dto.response.MedicineInfoDto;
 import com.allergenie.server.dto.response.MedicineListDto;
 import com.allergenie.server.service.MedicineService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,8 +15,11 @@ public class MedicineController {
     private final MedicineService medicineService;
 
     @GetMapping
-    public MedicineListDto getMedicineListBySearch(@RequestParam("search") String search) {
-        return medicineService.getMedicineListBySearch(search);
+    public MedicineListDto getMedicineListBySearch(
+            @RequestParam(name = "search") String search,
+            @RequestParam(name = "pageNo") int pageNo) {
+        Pageable pageable = PageRequest.of(pageNo, 4);
+        return medicineService.getMedicineListBySearch(search, pageable);
     }
 
     @GetMapping("/{medicineId}")

--- a/src/main/java/com/allergenie/server/dto/response/MedicineDto.java
+++ b/src/main/java/com/allergenie/server/dto/response/MedicineDto.java
@@ -1,0 +1,20 @@
+package com.allergenie.server.dto.response;
+
+import com.allergenie.server.domain.Medicine;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MedicineDto {
+    private Long medicineId;
+    private String name;
+
+    @Builder
+    public MedicineDto(Medicine medicine) {
+        this.medicineId = medicine.getId();
+        this.name = medicine.getName();
+
+    }
+}

--- a/src/main/java/com/allergenie/server/dto/response/MedicineInfoDto.java
+++ b/src/main/java/com/allergenie/server/dto/response/MedicineInfoDto.java
@@ -1,0 +1,28 @@
+package com.allergenie.server.dto.response;
+
+import com.allergenie.server.domain.Medicine;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MedicineInfoDto {
+    private Long medicineId;
+    private String image;
+    private String name;
+    private String effect;
+//    private String sideEffect;
+    private String caution;
+
+    @Builder
+    public MedicineInfoDto(Medicine medicine) {
+        this.medicineId = medicine.getId();
+        this.image = medicine.getImage();
+        this.name = medicine.getName();
+        this.effect = medicine.getEffect();
+//        this.sideEffect
+        this.caution = medicine.getCaution();
+    }
+}

--- a/src/main/java/com/allergenie/server/dto/response/MedicineListDto.java
+++ b/src/main/java/com/allergenie/server/dto/response/MedicineListDto.java
@@ -1,0 +1,23 @@
+package com.allergenie.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MedicineListDto {
+    private int totalPage;
+    private int currentPage;
+    private List<MedicineDto> medicineList;
+
+    @Builder
+    public MedicineListDto(int totalPage, int currentPage, List<MedicineDto> medicineList) {
+        this.totalPage = totalPage;
+        this.currentPage = currentPage;
+        this.medicineList = medicineList;
+    }
+}

--- a/src/main/java/com/allergenie/server/repository/MedicineRepository.java
+++ b/src/main/java/com/allergenie/server/repository/MedicineRepository.java
@@ -1,9 +1,18 @@
 package com.allergenie.server.repository;
 
 import com.allergenie.server.domain.Medicine;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MedicineRepository extends JpaRepository<Medicine, Long> {
+    @Query("SELECT m FROM Medicine m " +
+            "WHERE m.name LIKE CONCAT('%', :search, '%') " +
+            "ORDER BY CASE WHEN m.name = :search THEN 0 ELSE 1 END, m.name ASC")
+    Page<Medicine> findByNameContaining(@Param("search") String search, Pageable pageable);
+
 }

--- a/src/main/java/com/allergenie/server/service/MedicineService.java
+++ b/src/main/java/com/allergenie/server/service/MedicineService.java
@@ -1,10 +1,13 @@
 package com.allergenie.server.service;
 
 import com.allergenie.server.domain.Medicine;
+import com.allergenie.server.dto.response.MedicineDto;
 import com.allergenie.server.dto.response.MedicineInfoDto;
 import com.allergenie.server.dto.response.MedicineListDto;
 import com.allergenie.server.repository.MedicineRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +19,10 @@ import org.springframework.web.server.ResponseStatusException;
 public class MedicineService {
     private final MedicineRepository medicineRepository;
 
-    public MedicineListDto getMedicineListBySearch(String search) {
-
+    public MedicineListDto getMedicineListBySearch(String search, Pageable pageable) {
+        Page<Medicine> searchedMedicines = medicineRepository.findByNameContaining(search, pageable);
+        Page<MedicineDto> medicineDtos = searchedMedicines.map(MedicineDto::new);
+        return new MedicineListDto(medicineDtos.getTotalPages(), medicineDtos.getNumber(), medicineDtos.getContent());
     }
 
     public MedicineInfoDto getMedicineInfo(Long medicineId) {

--- a/src/main/java/com/allergenie/server/service/MedicineService.java
+++ b/src/main/java/com/allergenie/server/service/MedicineService.java
@@ -1,0 +1,29 @@
+package com.allergenie.server.service;
+
+import com.allergenie.server.domain.Medicine;
+import com.allergenie.server.dto.response.MedicineInfoDto;
+import com.allergenie.server.dto.response.MedicineListDto;
+import com.allergenie.server.repository.MedicineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MedicineService {
+    private final MedicineRepository medicineRepository;
+
+    public MedicineListDto getMedicineListBySearch(String search) {
+
+    }
+
+    public MedicineInfoDto getMedicineInfo(Long medicineId) {
+        Medicine medicine = medicineRepository.findById(medicineId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return new MedicineInfoDto(medicine);
+    }
+
+}


### PR DESCRIPTION
2023.11.16

1. 약 이름으로 검색
* 약 이름으로 검색 시, 검색어가 포함된 약 리스트 반환
* 정확도 순
* `/api/v1/home?search={search}&pageNo={pageNo}`
2. 약 상세 정보
* 약 리스트에서 약 선택 시, 해당 약의 상세 정보 반환
* `/api/v1/home/{medicineId}`